### PR TITLE
use `herumi/bls-wasm` instead of `dfinity/js-bls-lib`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 
-# distributed key generation
+# Distributed Key Generation
 
-## **WIP**
-
-This is a fork of [dfinity/dkg](https://github.com/dfinity/dkg) which uses [herumi/bls-wasm](https://github.com/herumi/bls-wasm) instead of [dfinity/js-bls-lib](https://github.com/dfinity/js-bls-lib)
-
-The API is almost the same, except some methods no longer require passing in an instance of the bls library,
+Distributed key generation using [herumi/bls-wasm](https://github.com/herumi/bls-wasm).
 
 # USAGE
 [./example.js](./example.js)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
-# SYNOPSIS 
-[![NPM Package](https://img.shields.io/npm/v/dkg.svg?style=flat-square)](https://www.npmjs.org/package/dkg)
-[![Build Status](https://img.shields.io/travis/wanderer/dkg.svg?branch=master&style=flat-square)](https://travis-ci.org/wanderer/dkg)
-[![Coverage Status](https://img.shields.io/coveralls/wanderer/dkg.svg?style=flat-square)](https://coveralls.io/r/wanderer/dkg)
 
-[![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)  
+# distributed key generation
 
-[Distributed key generation](https://en.wikipedia.org/wiki/Distributed_key_generation) primitives in JS. With this you can create a "group" with a threshold that has a shared secert and a public key for the group. This group can then sign on messages and when the threshold number of members sign anyone can create recover the groups signture on the message which can be validated against the groups public key. The signiture is also determinist no matter which members on the message.
+## **WIP**
 
-# INSTALL
-`npm install dkg`
+This is a fork of [dfinity/dkg](https://github.com/dfinity/dkg) which uses [herumi/bls-wasm](https://github.com/herumi/bls-wasm) instead of [dfinity/js-bls-lib](https://github.com/dfinity/js-bls-lib)
+
+The API is almost the same, except some methods no longer require passing in an instance of the bls library,
 
 # USAGE
 [./example.js](./example.js)

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,13 @@
 
 ## generateContribution
 
-[index.js:10-41][11]
+[index.js:10-40][11]
 
 generates a members contribution to the DKG
 
 ### Parameters
 
--   `bls` **[Object][12]** an instance of [bls-lib][13]
+-   `bls` **[Object][12]** an instance of [bls-wasm][13]
 -   `ids` **[Array][14]&lt;[Number][15]>** an array of pointers containing the ids of the members of the groups
 -   `threshold` **[Number][15]** the threshold number of members needed to sign on a message to
     produce the groups signature
@@ -31,13 +31,13 @@ and `secretKeyContribution` which is an array of secret key pointers
 
 ## generateZeroContribution
 
-[index.js:52-92][16]
+[index.js:51-90][16]
 
 generates a members contribution to the DKG, ensuring the secret is null
 
 ### Parameters
 
--   `bls` **[Object][12]** an instance of [bls-lib][13]
+-   `bls` **[Object][12]** an instance of [bls-wasm][13]
 -   `ids` **[Array][14]&lt;[Number][15]>** an array of pointers containing the ids of the members of the groups
 -   `threshold` **[Number][15]** the threshold number of members needed to sign on a message to
     produce the groups signature
@@ -47,26 +47,25 @@ and `secretKeyContribution` which is an array of secret key pointers
 
 ## addContributionShares
 
-[index.js:100-107][17]
+[index.js:97-104][17]
 
 Adds secret key contribution together to produce a single secret key
 
 ### Parameters
 
--   `bls` **[Object][12]** an instance of [bls-lib][13]
 -   `secretKeyShares` **[Array][14]&lt;[Number][15]>** an array of pointer to secret keys to add
 
 Returns **[Number][15]** a pointer to the resulting secret key
 
 ## verifyContributionShare
 
-[index.js:118-131][18]
+[index.js:115-127][18]
 
 Verifies a contribution share
 
 ### Parameters
 
--   `bls` **[Object][12]** an instance of [bls-lib][13]
+-   `bls` **[Object][12]** an instance of [bls-wasm][13]
 -   `id` **[Number][15]** a pointer to the id of the member verifiing the contribution
 -   `contribution` **[Number][15]** a pointer to the secret key contribution
 -   `vvec` **[Array][14]&lt;[Number][15]>** an array of pointers to public keys which is
@@ -76,13 +75,12 @@ Returns **[Boolean][19]**
 
 ## addVerificationVectors
 
-[index.js:138-152][20]
+[index.js:133-147][20]
 
 Adds an array of verification vectors together to produce the groups verification vector
 
 ### Parameters
 
--   `bls` **[Object][12]** an instance of [bls-lib][13]
 -   `vvecs` **[Array][14]&lt;[Array][14]&lt;[Number][15]>>** an array containing all the groups verifciation vectors
 
 [1]: #generatecontribution
@@ -105,22 +103,22 @@ Adds an array of verification vectors together to produce the groups verificatio
 
 [10]: #parameters-4
 
-[11]: https://github.com/wanderer/dkg/blob/6fff33d3e3b08ffbbfc0e3a9ef448bd8dfab6d68/index.js#L10-L41 "Source code on GitHub"
+[11]: https://gitlab.com/dark-crystal/dkg/blob/83c8081bbf39483736f3dd29c759c1f07f436332/index.js#L10-L40 "Source code on GitHub"
 
 [12]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-[13]: https://github.com/wanderer/bls-lib
+[13]: https://github.com/herumi/bls-wasm
 
 [14]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
 
 [15]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-[16]: https://github.com/wanderer/dkg/blob/6fff33d3e3b08ffbbfc0e3a9ef448bd8dfab6d68/index.js#L52-L92 "Source code on GitHub"
+[16]: https://gitlab.com/dark-crystal/dkg/blob/83c8081bbf39483736f3dd29c759c1f07f436332/index.js#L51-L90 "Source code on GitHub"
 
-[17]: https://github.com/wanderer/dkg/blob/6fff33d3e3b08ffbbfc0e3a9ef448bd8dfab6d68/index.js#L100-L107 "Source code on GitHub"
+[17]: https://gitlab.com/dark-crystal/dkg/blob/83c8081bbf39483736f3dd29c759c1f07f436332/index.js#L97-L104 "Source code on GitHub"
 
-[18]: https://github.com/wanderer/dkg/blob/6fff33d3e3b08ffbbfc0e3a9ef448bd8dfab6d68/index.js#L118-L131 "Source code on GitHub"
+[18]: https://gitlab.com/dark-crystal/dkg/blob/83c8081bbf39483736f3dd29c759c1f07f436332/index.js#L115-L127 "Source code on GitHub"
 
 [19]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean
 
-[20]: https://github.com/wanderer/dkg/blob/6fff33d3e3b08ffbbfc0e3a9ef448bd8dfab6d68/index.js#L138-L152 "Source code on GitHub"
+[20]: https://gitlab.com/dark-crystal/dkg/blob/83c8081bbf39483736f3dd29c759c1f07f436332/index.js#L133-L147 "Source code on GitHub"

--- a/example.js
+++ b/example.js
@@ -1,7 +1,7 @@
-const bls = require('bls-lib')
+const bls = require('bls-wasm')
 const dkg = require('./')
 
-bls.onModuleInit(() => {
+bls.init().then(() => {
   // We are going to walk through Distributed Key Generation.
   // In DKG a group of members generate a "shared secret key" that none of them
   // know individal and public key. When a threshold amount of group members agree to sign on
@@ -23,16 +23,14 @@ bls.onModuleInit(() => {
   // 5) After members receive all thier contribution shares they compute
   // their secret key for the group
 
-  bls.init()
-
   // to setup a group first we need a set a threshold. The threshold is the
   // number of group participants need to create a valid siganture for the group
   const threshold = 4
   // each member in the group needs a unique ID. What the id is doesn't matter
   // but it does need to be imported into bls-lib as a secret key
   const members = [10314, 30911, 25411, 8608, 31524, 15441, 23399].map(id => {
-    const sk = bls.secretKey()
-    bls.hashToSecretKey(sk, Buffer.from([id]))
+    const sk = new bls.SecretKey()
+    sk.setHashOf(Buffer.from([id]))
     return {
       id: sk,
       recievedShares: []
@@ -68,22 +66,21 @@ bls.onModuleInit(() => {
   // now each members adds together all received secret key contributions shares to get a
   // single secretkey share for the group used for signing message for the group
   members.forEach((member, i) => {
-    const sk = dkg.addContributionShares(bls, member.recievedShares)
+    const sk = dkg.addContributionShares(member.recievedShares)
     member.secretKeyShare = sk
   })
   console.log('-> secret shares have been generated')
 
   // Now any one can add together the all verification vectors posted by the
   // members of the group to get a single verification vector of for the group
-  const groupsVvec = dkg.addVerificationVectors(bls, vvecs)
+  const groupsVvec = dkg.addVerificationVectors(vvecs)
   console.log('-> verification vector computed')
 
   // the groups verifcation vector contains the groups public key. The group's
   // public key is the first element in the array
   const groupsPublicKey = groupsVvec[0]
 
-  const pubArray = bls.publicKeyExport(groupsPublicKey)
-  console.log('-> group public key : ', Buffer.from(pubArray).toString('hex'))
+  console.log('-> group public key : ', groupsPublicKey.serializeToHexStr())
 
   console.log('-> testing signature')
   // now we can select any 4 members to sign on a message
@@ -91,119 +88,116 @@ bls.onModuleInit(() => {
   const sigs = []
   const signersIds = []
   for (let i = 0; i < threshold; i++) {
-    const sig = bls.signature()
-    bls.sign(sig, members[i].secretKeyShare, message)
+    const sig = members[i].secretKeyShare.sign(message)
     sigs.push(sig)
     signersIds.push(members[i].id)
   }
 
   // then anyone can combine the signatures to get the groups signature
   // the resulting signature will also be the same no matter which members signed
-  const groupsSig = bls.signature()
-  bls.signatureRecover(groupsSig, sigs, signersIds)
+  const groupsSig = new bls.Signature()
+  groupsSig.recover(sigs, signersIds)
 
-  const sigArray = bls.signatureExport(groupsSig)
-  const sigBuf = Buffer.from(sigArray)
-  console.log('->    sigtest result : ', sigBuf.toString('hex'))
+  console.log('->    sigtest result : ', groupsSig.serializeToHexStr())
 
-  var verified = bls.verify(groupsSig, groupsPublicKey, message)
+  var verified = groupsPublicKey.verify(groupsSig, message)
   console.log('->    verified ?', Boolean(verified))
-  bls.free(groupsSig)
+  groupsSig.clear()
 
-  console.log('-> testing individual public key derivation')
-  // we can also use the groups verification vector to derive any of the members
-  // public key
-  const member = members[4]
-  const pk1 = bls.publicKey()
-  bls.publicKeyShare(pk1, groupsVvec, member.id)
-
-  const pk2 = bls.publicKey()
-  bls.getPublicKey(pk2, member.secretKeyShare)
-  console.log('->    are the public keys equal?', Boolean(bls.publicKeyIsEqual(pk1, pk2)))
-
-  console.log('\nBeginning the share renewal round...')
-
-  const newVvecs = [groupsVvec]
-
-  console.log('-> member shares array reinitialized')
-  members.forEach(member => {
-    member.recievedShares.length = 0
-    member.recievedShares.push(member.secretKeyShare)
-  })
-
-  console.log('-> running null-secret contribution generator')
-  // the process is very similar, only `generateZeroContribution` works with a null secret
-  members.forEach(id => {
-    const {verificationVector, secretKeyContribution} = dkg.generateZeroContribution(bls, members.map(m => m.id), threshold)
-    // the verification vector should be posted publically so that everyone
-    // in the group can see it
-    newVvecs.push(verificationVector)
-
-    // Each secret key contribution is then encrypted and sent to the member it is for.
-    secretKeyContribution.forEach((sk, i) => {
-      // when a group member receives its share, it verifies it against the
-      // verification vector of the sender and then saves it
-      const member = members[i]
-      const verified = dkg.verifyContributionShare(bls, member.id, sk, verificationVector)
-      if (!verified) {
-        throw new Error('invalid share!')
-      }
-      member.recievedShares.push(sk)
-    })
-  })
-
-  // now each members adds together all received secret key contributions shares to get a
-  // single secretkey share for the group used for signing message for the group
-  members.forEach((member, i) => {
-    const sk = dkg.addContributionShares(bls, member.recievedShares)
-    member.secretKeyShare = sk
-  })
-  console.log('-> new secret shares have been generated')
-
-  // Now any one can add together the all verification vectors posted by the
-  // members of the group to get a single verification vector of for the group
-  const newGroupsVvec = dkg.addVerificationVectors(bls, newVvecs)
-  console.log('-> verification vector computed')
-
-  // the groups verifcation vector contains the groups public key. The group's
-  // public key is the first element in the array
-  const newGroupsPublicKey = newGroupsVvec[0]
-
-  verified = (bls.publicKeyIsEqual(newGroupsPublicKey, groupsPublicKey))
-  console.log('-> public key should not have changed :', (verified ? 'success' : 'failure'))
-
-  console.log('-> testing signature using new shares')
-  // now we can select any 4 members to sign on a message
-  sigs.length = 0
-  signersIds.length = 0
-  for (let i = 0; i < threshold; i++) {
-    const sig = bls.signature()
-    bls.sign(sig, members[i].secretKeyShare, message)
-    sigs.push(sig)
-    signersIds.push(members[i].id)
-  }
-
-  // then anyone can combine the signatures to get the groups signature
-  // the resulting signature will also be the same no matter which members signed
-  const groupsNewSig = bls.signature()
-  bls.signatureRecover(groupsNewSig, sigs, signersIds)
-
-  const newSigArray = bls.signatureExport(groupsNewSig)
-  const newSigBuf = Buffer.from(newSigArray)
-  console.log('->    sigtest result : ', newSigBuf.toString('hex'))
-  console.log('->    signature comparison :', ((newSigBuf.equals(sigBuf)) ? 'success' : 'failure'))
-
-  verified = bls.verify(groupsNewSig, groupsPublicKey, message)
-  console.log('->    verified ?', Boolean(verified))
-  bls.free(groupsNewSig)
-
-  // don't forget to clean up!
-  bls.free(pk1)
-  bls.free(pk2)
-  bls.freeArray(groupsVvec)
-  bls.freeArray(newGroupsVvec)
-  members.forEach(m => {
-    bls.free(m.secretKeyShare)
-    bls.free(m.id)
-  })
+  // console.log('-> testing individual public key derivation')
+  // // we can also use the groups verification vector to derive any of the members
+  // // public key
+  // const member = members[4]
+  // const pk1 = bls.publicKey()
+  // bls.publicKeyShare(pk1, groupsVvec, member.id)
+  //
+  // const pk2 = bls.publicKey()
+  // bls.getPublicKey(pk2, member.secretKeyShare)
+  // console.log('->    are the public keys equal?', Boolean(bls.publicKeyIsEqual(pk1, pk2)))
+  //
+  // console.log('\nBeginning the share renewal round...')
+  //
+  // const newVvecs = [groupsVvec]
+  //
+  // console.log('-> member shares array reinitialized')
+  // members.forEach(member => {
+  //   member.recievedShares.length = 0
+  //   member.recievedShares.push(member.secretKeyShare)
+  // })
+  //
+  // console.log('-> running null-secret contribution generator')
+  // // the process is very similar, only `generateZeroContribution` works with a null secret
+  // members.forEach(id => {
+  //   const {verificationVector, secretKeyContribution} = dkg.generateZeroContribution(bls, members.map(m => m.id), threshold)
+  //   // the verification vector should be posted publically so that everyone
+  //   // in the group can see it
+  //   newVvecs.push(verificationVector)
+  //
+  //   // Each secret key contribution is then encrypted and sent to the member it is for.
+  //   secretKeyContribution.forEach((sk, i) => {
+  //     // when a group member receives its share, it verifies it against the
+  //     // verification vector of the sender and then saves it
+  //     const member = members[i]
+  //     const verified = dkg.verifyContributionShare(bls, member.id, sk, verificationVector)
+  //     if (!verified) {
+  //       throw new Error('invalid share!')
+  //     }
+  //     member.recievedShares.push(sk)
+  //   })
+  // })
+  //
+  // // now each members adds together all received secret key contributions shares to get a
+  // // single secretkey share for the group used for signing message for the group
+  // members.forEach((member, i) => {
+  //   const sk = dkg.addContributionShares(bls, member.recievedShares)
+  //   member.secretKeyShare = sk
+  // })
+  // console.log('-> new secret shares have been generated')
+  //
+  // // Now any one can add together the all verification vectors posted by the
+  // // members of the group to get a single verification vector of for the group
+  // const newGroupsVvec = dkg.addVerificationVectors(bls, newVvecs)
+  // console.log('-> verification vector computed')
+  //
+  // // the groups verifcation vector contains the groups public key. The group's
+  // // public key is the first element in the array
+  // const newGroupsPublicKey = newGroupsVvec[0]
+  //
+  // verified = (bls.publicKeyIsEqual(newGroupsPublicKey, groupsPublicKey))
+  // console.log('-> public key should not have changed :', (verified ? 'success' : 'failure'))
+  //
+  // console.log('-> testing signature using new shares')
+  // // now we can select any 4 members to sign on a message
+  // sigs.length = 0
+  // signersIds.length = 0
+  // for (let i = 0; i < threshold; i++) {
+  //   const sig = bls.signature()
+  //   bls.sign(sig, members[i].secretKeyShare, message)
+  //   sigs.push(sig)
+  //   signersIds.push(members[i].id)
+  // }
+  //
+  // // then anyone can combine the signatures to get the groups signature
+  // // the resulting signature will also be the same no matter which members signed
+  // const groupsNewSig = bls.signature()
+  // bls.signatureRecover(groupsNewSig, sigs, signersIds)
+  //
+  // const newSigArray = bls.signatureExport(groupsNewSig)
+  // const newSigBuf = Buffer.from(newSigArray)
+  // console.log('->    sigtest result : ', newSigBuf.toString('hex'))
+  // console.log('->    signature comparison :', ((newSigBuf.equals(sigBuf)) ? 'success' : 'failure'))
+  //
+  // verified = bls.verify(groupsNewSig, groupsPublicKey, message)
+  // console.log('->    verified ?', Boolean(verified))
+  // bls.free(groupsNewSig)
+  //
+  // // don't forget to clean up!
+  // bls.free(pk1)
+  // bls.free(pk2)
+  // bls.freeArray(groupsVvec)
+  // bls.freeArray(newGroupsVvec)
+  // members.forEach(m => {
+  //   bls.free(m.secretKeyShare)
+  //   bls.free(m.id)
+  // })
 })

--- a/example.js
+++ b/example.js
@@ -104,100 +104,96 @@ bls.init().then(() => {
   console.log('->    verified ?', Boolean(verified))
   groupsSig.clear()
 
-  // console.log('-> testing individual public key derivation')
-  // // we can also use the groups verification vector to derive any of the members
-  // // public key
-  // const member = members[4]
-  // const pk1 = bls.publicKey()
-  // bls.publicKeyShare(pk1, groupsVvec, member.id)
-  //
-  // const pk2 = bls.publicKey()
-  // bls.getPublicKey(pk2, member.secretKeyShare)
-  // console.log('->    are the public keys equal?', Boolean(bls.publicKeyIsEqual(pk1, pk2)))
-  //
-  // console.log('\nBeginning the share renewal round...')
-  //
-  // const newVvecs = [groupsVvec]
-  //
-  // console.log('-> member shares array reinitialized')
-  // members.forEach(member => {
-  //   member.recievedShares.length = 0
-  //   member.recievedShares.push(member.secretKeyShare)
-  // })
-  //
-  // console.log('-> running null-secret contribution generator')
-  // // the process is very similar, only `generateZeroContribution` works with a null secret
-  // members.forEach(id => {
-  //   const {verificationVector, secretKeyContribution} = dkg.generateZeroContribution(bls, members.map(m => m.id), threshold)
-  //   // the verification vector should be posted publically so that everyone
-  //   // in the group can see it
-  //   newVvecs.push(verificationVector)
-  //
-  //   // Each secret key contribution is then encrypted and sent to the member it is for.
-  //   secretKeyContribution.forEach((sk, i) => {
-  //     // when a group member receives its share, it verifies it against the
-  //     // verification vector of the sender and then saves it
-  //     const member = members[i]
-  //     const verified = dkg.verifyContributionShare(bls, member.id, sk, verificationVector)
-  //     if (!verified) {
-  //       throw new Error('invalid share!')
-  //     }
-  //     member.recievedShares.push(sk)
-  //   })
-  // })
-  //
-  // // now each members adds together all received secret key contributions shares to get a
-  // // single secretkey share for the group used for signing message for the group
-  // members.forEach((member, i) => {
-  //   const sk = dkg.addContributionShares(bls, member.recievedShares)
-  //   member.secretKeyShare = sk
-  // })
-  // console.log('-> new secret shares have been generated')
-  //
-  // // Now any one can add together the all verification vectors posted by the
-  // // members of the group to get a single verification vector of for the group
-  // const newGroupsVvec = dkg.addVerificationVectors(bls, newVvecs)
-  // console.log('-> verification vector computed')
-  //
-  // // the groups verifcation vector contains the groups public key. The group's
-  // // public key is the first element in the array
-  // const newGroupsPublicKey = newGroupsVvec[0]
-  //
-  // verified = (bls.publicKeyIsEqual(newGroupsPublicKey, groupsPublicKey))
-  // console.log('-> public key should not have changed :', (verified ? 'success' : 'failure'))
-  //
-  // console.log('-> testing signature using new shares')
-  // // now we can select any 4 members to sign on a message
-  // sigs.length = 0
-  // signersIds.length = 0
-  // for (let i = 0; i < threshold; i++) {
-  //   const sig = bls.signature()
-  //   bls.sign(sig, members[i].secretKeyShare, message)
-  //   sigs.push(sig)
-  //   signersIds.push(members[i].id)
-  // }
-  //
-  // // then anyone can combine the signatures to get the groups signature
-  // // the resulting signature will also be the same no matter which members signed
-  // const groupsNewSig = bls.signature()
-  // bls.signatureRecover(groupsNewSig, sigs, signersIds)
-  //
-  // const newSigArray = bls.signatureExport(groupsNewSig)
-  // const newSigBuf = Buffer.from(newSigArray)
-  // console.log('->    sigtest result : ', newSigBuf.toString('hex'))
-  // console.log('->    signature comparison :', ((newSigBuf.equals(sigBuf)) ? 'success' : 'failure'))
-  //
-  // verified = bls.verify(groupsNewSig, groupsPublicKey, message)
-  // console.log('->    verified ?', Boolean(verified))
-  // bls.free(groupsNewSig)
-  //
-  // // don't forget to clean up!
-  // bls.free(pk1)
-  // bls.free(pk2)
-  // bls.freeArray(groupsVvec)
-  // bls.freeArray(newGroupsVvec)
-  // members.forEach(m => {
-  //   bls.free(m.secretKeyShare)
-  //   bls.free(m.id)
-  // })
+  console.log('-> testing individual public key derivation')
+  // we can also use the groups verification vector to derive any of the members
+  // public key
+  const member = members[4]
+  const pk1 = new bls.PublicKey()
+  pk1.share(groupsVvec, member.id)
+
+  const pk2 = member.secretKeyShare.getPublicKey()
+  console.log('->    are the public keys equal?', Boolean(pk1.isEqual(pk2)))
+
+  console.log('\nBeginning the share renewal round...')
+
+  const newVvecs = [groupsVvec]
+
+  console.log('-> member shares array reinitialized')
+  members.forEach(member => {
+    member.recievedShares.length = 0
+    member.recievedShares.push(member.secretKeyShare)
+  })
+
+  console.log('-> running null-secret contribution generator')
+  // the process is very similar, only `generateZeroContribution` works with a null secret
+  members.forEach(id => {
+    const {verificationVector, secretKeyContribution} = dkg.generateZeroContribution(bls, members.map(m => m.id), threshold)
+    // the verification vector should be posted publically so that everyone
+    // in the group can see it
+    newVvecs.push(verificationVector)
+
+    // Each secret key contribution is then encrypted and sent to the member it is for.
+    secretKeyContribution.forEach((sk, i) => {
+      // when a group member receives its share, it verifies it against the
+      // verification vector of the sender and then saves it
+      const member = members[i]
+      const verified = dkg.verifyContributionShare(bls, member.id, sk, verificationVector)
+      if (!verified) {
+        throw new Error('invalid share!')
+      }
+      member.recievedShares.push(sk)
+    })
+  })
+
+  // now each members adds together all received secret key contributions shares to get a
+  // single secretkey share for the group used for signing message for the group
+  members.forEach((member, i) => {
+    const sk = dkg.addContributionShares(member.recievedShares)
+    member.secretKeyShare = sk
+  })
+  console.log('-> new secret shares have been generated')
+
+  // Now any one can add together the all verification vectors posted by the
+  // members of the group to get a single verification vector of for the group
+  const newGroupsVvec = dkg.addVerificationVectors(newVvecs)
+  console.log('-> verification vector computed')
+
+  // the groups verifcation vector contains the groups public key. The group's
+  // public key is the first element in the array
+  const newGroupsPublicKey = newGroupsVvec[0]
+
+  verified = newGroupsPublicKey.isEqual(groupsPublicKey)
+  console.log('-> public key should not have changed :', (verified ? 'success' : 'failure'))
+
+  console.log('-> testing signature using new shares')
+  // now we can select any 4 members to sign on a message
+  sigs.length = 0
+  signersIds.length = 0
+  for (let i = 0; i < threshold; i++) {
+    const sig = members[i].secretKeyShare.sign(message)
+    sigs.push(sig)
+    signersIds.push(members[i].id)
+  }
+
+  // then anyone can combine the signatures to get the groups signature
+  // the resulting signature will also be the same no matter which members signed
+  const groupsNewSig = new bls.Signature()
+  groupsNewSig.recover(sigs, signersIds)
+
+  console.log('->    sigtest result : ', groupsNewSig.serializeToHexStr())
+  console.log('->    signature comparison :', (groupsSig.isEqual(groupsNewSig) ? 'success' : 'failure'))
+
+  verified = groupsPublicKey.verify(groupsNewSig, message)
+  console.log('->    verified ?', Boolean(verified))
+  groupsNewSig.clear()
+
+  // don't forget to clean up!
+  pk1.clear()
+  pk2.clear()
+  groupsVvec.forEach(v => v.clear())
+  newGroupsVvec.forEach(v => v.clear())
+  members.forEach(m => {
+    m.secretKeyShare.clear()
+    m.id.clear()
+  })
 })

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 /**
  * generates a members contribution to the DKG
- * @param {Object} bls - an instance of [bls-lib](https://github.com/wanderer/bls-lib)
+ * @param {Object} bls - an instance of [bls-wasm](https://github.com/herumi/bls-wasm)
  * @param {Array<Number>} ids - an array of pointers containing the ids of the members of the groups
  * @param {Number} threshold - the threshold number of members needed to sign on a message to
  * produce the groups signature
@@ -41,7 +41,7 @@ exports.generateContribution = function (bls, ids, threshold) {
 
 /**
  * generates a members contribution to the DKG, ensuring the secret is null
- * @param {Object} bls - an instance of [bls-lib](https://github.com/wanderer/bls-lib)
+ * @param {Object} bls - an instance of [bls-wasm](https://github.com/herumi/bls-wasm)
  * @param {Array<Number>} ids - an array of pointers containing the ids of the members of the groups
  * @param {Number} threshold - the threshold number of members needed to sign on a message to
  * produce the groups signature
@@ -105,7 +105,7 @@ exports.addContributionShares = function (secretKeyShares) {
 
 /**
  * Verifies a contribution share
- * @param {Object} bls - an instance of [bls-lib](https://github.com/wanderer/bls-lib)
+ * @param {Object} bls - an instance of [bls-wasm](https://github.com/herumi/bls-wasm)
  * @param {Number} id - a pointer to the id of the member verifiing the contribution
  * @param {Number} contribution - a pointer to the secret key contribution
  * @param {Array<Number>} vvec - an array of pointers to public keys which is

--- a/index.js
+++ b/index.js
@@ -17,7 +17,57 @@ exports.generateContribution = function (bls, ids, threshold) {
   // generate a sk and vvec
   for (let i = 0; i < threshold; i++) {
     const sk = new bls.SecretKey()
-    sk.setByCSPRNG(sk)
+    sk.setByCSPRNG()
+    svec.push(sk)
+
+    const pk = sk.getPublicKey()
+    vvec.push(pk)
+  }
+
+  // generate key shares
+  for (const id of ids) {
+    const sk = new bls.SecretKey()
+    sk.share(svec, id)
+    skContribution.push(sk)
+  }
+
+  svec.forEach(s => s.clear())
+
+  return {
+    verificationVector: vvec,
+    secretKeyContribution: skContribution
+  }
+}
+
+/**
+ * generates a members contribution to the DKG, ensuring the secret is null
+ * @param {Object} bls - an instance of [bls-lib](https://github.com/wanderer/bls-lib)
+ * @param {Array<Number>} ids - an array of pointers containing the ids of the members of the groups
+ * @param {Number} threshold - the threshold number of members needed to sign on a message to
+ * produce the groups signature
+ * @returns {Object} the object contains `verificationVector` which is an array of public key pointers
+ * and `secretKeyContribution` which is an array of secret key pointers
+ */
+exports.generateZeroContribution = function (bls, ids, threshold) {
+  // this id's verification vector
+  const vvec = []
+  // this id's secret keys
+  const svec = []
+  // this id's sk contributions shares
+  const skContribution = []
+
+  const zeroArray = Buffer.alloc(32)
+  const zeroSK = new bls.SecretKey()
+  zeroSK.deserialize(zeroArray)
+  svec.push(zeroSK)
+
+  const zeroPK = zeroSK.getPublicKey()
+  vvec.push(zeroPK)
+
+  // generate a sk and vvec
+  for (let i = 1; i < threshold; i++) {
+    const sk = new bls.SecretKey()
+    sk.setByCSPRNG()
     svec.push(sk)
 
     const pk = sk.getPublicKey()
@@ -41,7 +91,6 @@ exports.generateContribution = function (bls, ids, threshold) {
 
 /**
  * Adds secret key contribution together to produce a single secret key
- * @param {Object} bls - an instance of [bls-lib](https://github.com/wanderer/bls-lib)
  * @param {Array<Number>} secretKeyShares - an array of pointer to secret keys to add
  * @returns {Number} a pointer to the resulting secret key
  */
@@ -79,7 +128,6 @@ exports.verifyContributionShare = function (bls, id, contribution, vvec) {
 
 /**
  * Adds an array of verification vectors together to produce the groups verification vector
- * @param {Object} bls - an instance of [bls-lib](https://github.com/wanderer/bls-lib)
  * @param {Array<Array<Number>>} vvecs - an array containing all the groups verifciation vectors
  */
 exports.addVerificationVectors = function (vvecs) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -214,6 +214,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1461,15 +1462,11 @@
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
-    "bls-lib": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/bls-lib/-/bls-lib-0.3.4.tgz",
-      "integrity": "sha512-lLohYHjxB1Syo4jI8Fa0UPvyl4VgtOGQAsLmTUATQ/ktmRITA/N840x8zNUCyM4uju3EEQtGnNnTOfc2AHOxJQ==",
-      "dev": true,
-      "requires": {
-        "nop": "^1.0.0",
-        "safe-buffer": "^5.1.1"
-      }
+    "bls-wasm": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/bls-wasm/-/bls-wasm-0.2.7.tgz",
+      "integrity": "sha512-nhdhgz4egxEeXkBMdkRpTeehBTI880EWZbAIXxJ6EVVx908V+UMLemCkQcAsFJnOOJOM3ku4MB8S8WUOWMDqKg==",
+      "dev": true
     },
     "body": {
       "version": "5.1.0",
@@ -3184,7 +3181,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3205,12 +3203,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3225,17 +3225,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3352,7 +3355,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3364,6 +3368,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3378,6 +3383,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3385,12 +3391,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3409,6 +3417,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3489,7 +3498,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3501,6 +3511,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3586,7 +3597,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3622,6 +3634,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3641,6 +3654,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3684,12 +3698,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4933,7 +4949,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "longest-streak": {
       "version": "2.0.2",
@@ -5363,12 +5380,6 @@
         "is-stream": "^1.0.1"
       }
     },
-    "nop": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nop/-/nop-1.0.0.tgz",
-      "integrity": "sha1-y0bPfgFXSqY5CFgUn2aJev5Tyco=",
-      "dev": true
-    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -5473,6 +5484,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -6415,7 +6427,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {},
   "devDependencies": {
     "array-shuffle": "^1.0.1",
-    "bls-lib": "^0.3.0",
+    "bls-wasm": "^0.2.7",
     "coveralls": "^3.0.1",
     "documentation": "^8.0.0",
     "istanbul": "^0.4.1",


### PR DESCRIPTION
Use [herumi/bls-wasm](https://github.com/herumi/bls-wasm) instead of [dfinity/js-bls-lib](https://github.com/dfinity/js-bls-lib).

This is different bindings to the same underlying BLS library.  These binding are maintained by the author of that C++ library, so (perhaps) more likely to be updated with changes to that library. 

The API is almost the same, except some methods no longer require passing in an instance of the bls library.  If we dont want an API breaking change we could allow the library to be passed in anyway.

If you'd rather not merge this, no problem, but let me know cos i would probably publish it to npm under another name.

Note that if merging we would need to rebuild the documentation as it contains absolute links which currently point to the fork.

@wanderer 